### PR TITLE
Timestamp and resource information

### DIFF
--- a/src/main/java/io/datanerds/avropatch/Patch.java
+++ b/src/main/java/io/datanerds/avropatch/Patch.java
@@ -29,7 +29,7 @@ public class Patch<T> {
 
     @SuppressWarnings("unused") // no-arg constructor needed by Avro
     private Patch() {
-        this(null, Collections.emptyList());
+        this(null);
     }
 
     /**
@@ -79,10 +79,16 @@ public class Patch<T> {
      * @param timestamp timestamp
      */
     public Patch(T resource, List<Operation> operations, Map<String, ?> headers, Date timestamp) {
-        this.operations = Collections.unmodifiableList(new ArrayList<>(operations));
+        Objects.nonNull(resource);
+        this.operations = unmodifiableNullableList(operations);
         this.resource = resource;
         this.timestamp = timestamp;
-        this.headers = Collections.unmodifiableMap(new HashMap<>(headers));
+        this.headers = Collections.unmodifiableMap(new HashMap<>(Optional.ofNullable(headers).orElse(Collections.emptyMap())));
+    }
+
+    private List<Operation> unmodifiableNullableList(List<Operation> operations) {
+        return Collections.unmodifiableList(
+                new ArrayList<>(Optional.ofNullable(operations).orElse(Collections.emptyList())));
     }
 
     public Operation getOperation(int index) {

--- a/src/main/java/io/datanerds/avropatch/Patch.java
+++ b/src/main/java/io/datanerds/avropatch/Patch.java
@@ -5,39 +5,127 @@ import io.datanerds.avropatch.operation.Operation;
 import org.apache.avro.reflect.AvroSchema;
 
 import javax.annotation.Generated;
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.*;
+import java.util.stream.Stream;
 
 /**
- * This class represents a JSON PATCH operation holding a sequence of operations to apply to a given object.
+ * This class represents a JSON PATCH operation holding a sequence of operations to apply to a given object. It provides
+ * shortcuts for accessing the list of operations and some additional fields for metadata information, such as the
+ * resource identifier, a timestamp and a {@link Map} holding arbitrary header information.
  *
  * @see <a href="https://tools.ietf.org/html/rfc6902">https://tools.ietf.org/html/rfc6902</a>
  */
-public class Patch {
+@ThreadSafe
+public class Patch<T> {
 
     @AvroSchema(DefaultSchema.HEADERS)
-    private final Map<String, ?> headers;
+    private final Map<String, ? super Object> headers;
+    @AvroSchema(DefaultSchema.VALUE)
+    private final T resource;
+    @AvroSchema(DefaultSchema.TIMESTAMP)
+    private final Date timestamp;
     private final List<Operation> operations;
 
     @SuppressWarnings("unused") // no-arg constructor needed by Avro
     private Patch() {
-        this(new ArrayList<>(), new HashMap<>());
+        this(null, Collections.emptyList());
     }
 
-    public Patch(List<Operation> operations) {
-        this(operations, Collections.EMPTY_MAP);
+    /**
+     * Minimalistic constructor setting the timestamp to {@code new Date()} and initializing the operation list and
+     * headers map with {@link Collections#emptyList()} / {@link Collections#emptyMap()}.
+     * @param resource resource identifier
+     */
+    public Patch(T resource) {
+        this(resource, Collections.emptyList(), Collections.emptyMap());
     }
 
-    public Patch(List<Operation> operations, Map<String, ?> headers) {
-        this.operations = new ArrayList<>(operations);
-        this.headers = new HashMap<>(headers);
+    /**
+     * This constructor sets the timestamp to {@code new Date()} and initializes the headers map with
+     * {@link Collections#emptyMap()}.
+     * @param resource resource identifier
+     * @param operations sequence of operations to apply to a object identifiable by {@code resource}
+     */
+    public Patch(T resource, List<Operation> operations) {
+        this(resource, operations, Collections.emptyMap());
     }
 
-    public List<Operation> getOperations() {
-        return Collections.unmodifiableList(operations);
+    /**
+     * This constructor sets the timestamp to {@code new Date()} and initializes the operation list with
+     * {@link Collections#emptyList()}.
+     * @param resource resource identifier
+     * @param headers arbitrary header information
+     */
+    public Patch(T resource, Map<String, ?> headers) {
+        this(resource, Collections.emptyList(), headers, new Date());
     }
 
-    public Map<String, ?> getHeaders() {
-        return Collections.unmodifiableMap(headers);
+    /**
+     * This constructor sets the timestamp to {@code new Date()}.
+     * @param resource resource identifier
+     * @param operations sequence of operations to apply to a object identifiable by {@code resource}
+     * @param headers arbitrary header information
+     */
+    public Patch(T resource, List<Operation> operations, Map<String, ?> headers) {
+        this(resource, operations, headers, new Date());
+    }
+
+    /**
+     *
+     * @param resource resource identifier
+     * @param operations sequence of operations to apply to a object identifiable by {@code resource}
+     * @param headers arbitrary header information
+     * @param timestamp timestamp
+     */
+    public Patch(T resource, List<Operation> operations, Map<String, ?> headers, Date timestamp) {
+        this.operations = Collections.unmodifiableList(new ArrayList<>(operations));
+        this.resource = resource;
+        this.timestamp = timestamp;
+        this.headers = Collections.unmodifiableMap(new HashMap<>(headers));
+    }
+
+    public Operation getOperation(int index) {
+        return operations.get(index);
+    }
+
+    public int size() {
+        return operations.size();
+    }
+
+    public Stream<Operation> stream() {
+        return operations.stream();
+    }
+
+    public boolean isEmpty() {
+        return operations.isEmpty();
+    }
+
+    public Map<String, ? super Object> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * Convenient method to retrieve and cast a specific header value.
+     * @param name name of the header
+     * @param <V> expected value type for given header
+     * @return header value if exists, {@code null} otherwise
+     * @throws ClassCastException
+     */
+    public <V> V getHeader(String name) {
+        return (V) headers.get(name);
+    }
+
+    public boolean hasHeader(String name) {
+        return headers.containsKey(name);
+    }
+
+    public T getResource() {
+        return resource;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
     }
 
     @Override
@@ -49,14 +137,16 @@ public class Patch {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Patch patch = (Patch) o;
+        Patch<T> patch = (Patch<T>) o;
         return Objects.equals(headers, patch.headers) &&
+                Objects.equals(resource, patch.resource) &&
+                Objects.equals(timestamp, patch.timestamp) &&
                 Objects.equals(operations, patch.operations);
     }
 
     @Override
     @Generated("IntelliJ IDEA")
     public int hashCode() {
-        return Objects.hash(headers, operations);
+        return Objects.hash(headers, resource, timestamp, operations);
     }
 }

--- a/src/main/java/io/datanerds/avropatch/operation/Path.java
+++ b/src/main/java/io/datanerds/avropatch/operation/Path.java
@@ -3,6 +3,7 @@ package io.datanerds.avropatch.operation;
 import io.datanerds.avropatch.exception.InvalidReferenceTokenException;
 
 import javax.annotation.Generated;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -138,8 +139,28 @@ public class Path {
         return new Path(parts.subList(0, parts.size() - 1));
     }
 
+    public Path leaf() {
+        if (parts.size() == 0) {
+            return ROOT;
+        }
+        return new Path(parts.subList(parts.size() - 1, parts.size()));
+    }
+
     public List<String> parts() {
         return parts;
+    }
+
+    public List<Path> subPaths() {
+        if (parts.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Path> subPaths = new ArrayList<>();
+        for (int i = 1; i <= parts.size(); i++) {
+            subPaths.add(new Path(parts.subList(0, i)));
+        }
+
+        return subPaths;
     }
 
     private static Function<Path, Stream<String>> partsStream() {

--- a/src/main/java/io/datanerds/avropatch/serialization/Types.java
+++ b/src/main/java/io/datanerds/avropatch/serialization/Types.java
@@ -1,12 +1,13 @@
 package io.datanerds.avropatch.serialization;
 
+import io.datanerds.avropatch.value.type.TimestampType;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 
 import java.util.Arrays;
 
+import static io.datanerds.avropatch.value.ValueSchemaBuilder.*;
 import static org.apache.avro.Schema.*;
-import static org.apache.avro.Schema.createRecord;
 
 /**
  * This class holds schemata for all patch {@link io.datanerds.avropatch.operation.Operation}s and
@@ -116,11 +117,20 @@ interface Types {
         String DOC = "This record represents a PATCH holding a sequence of operations to apply to a given object.";
 
         static Schema create(Schema valueSchema) {
+            Schema.Field headers = new Schema.Field("headers",
+                    mapBuilder().withSupportedTypes().with(arrayBuilder().withSupportedTypes().build()).build(),
+                    "Arbitrary header information.", NO_DEFAULT);
+            Schema.Field resource = new Schema.Field("resource",
+                    unionBuilder().withSupportedTypes().build(),
+                    "Identifier specifying which resource is targeted.", NO_DEFAULT);
+            Schema.Field timestamp = new Schema.Field("timestamp",
+                    TimestampType.SCHEMA,
+                    "Timestamp information.", NO_DEFAULT);
             Schema.Field operations = new Schema.Field("operations",
                     Schema.createArray(Types.Operation.create(valueSchema)),
                     "Sequence of operations to apply to a given object.", NO_DEFAULT);
-            return createRecord(NAME, DOC, PATCH_NAMESPACE, false, Arrays.asList(operations));
-
+            return createRecord(NAME, DOC, PATCH_NAMESPACE, false,
+                    Arrays.asList(headers, resource, timestamp, operations));
         }
     }
 }

--- a/src/main/java/io/datanerds/avropatch/value/DefaultSchema.java
+++ b/src/main/java/io/datanerds/avropatch/value/DefaultSchema.java
@@ -81,4 +81,11 @@ public interface DefaultSchema {
                     + "        \"logicalType\": \"uuid\"\n"
                     + "    }]\n"
                     + "}";
+    String TIMESTAMP =
+            "{"
+                    + "    \"type\": \"fixed\","
+                    + "    \"name\": \"timestamp\","
+                    + "    \"size\": 8,"
+                    + "    \"logicalType\": \"timestamp\""
+                    + "}";
 }

--- a/src/test/java/io/datanerds/avropatch/PatchTest.java
+++ b/src/test/java/io/datanerds/avropatch/PatchTest.java
@@ -96,12 +96,12 @@ public class PatchTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void immutableHeadersRemove() {
+    public void exceptionWhenRemovingImmutableHeaders() {
         new Patch<>(resource, operations, headers).getHeaders().remove("test 1");
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void immutableHeadersPut() {
+    public void exceptionWhenEditingImmutableHeaders() {
         new Patch<>(resource, operations, headers).getHeaders().put("foo", 22);
     }
 }

--- a/src/test/java/io/datanerds/avropatch/PatchTest.java
+++ b/src/test/java/io/datanerds/avropatch/PatchTest.java
@@ -4,36 +4,104 @@ import avro.shaded.com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import io.datanerds.avropatch.operation.Operation;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static io.datanerds.avropatch.operation.OperationGenerator.randomOperation;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
 
 public class PatchTest {
 
-    private final Map<String, ?> headers = ImmutableMap.of("test 1", "bla", "test 2", UUID.randomUUID());
+    private final UUID uuid = UUID.randomUUID();
+    private final Map<String, ?> headers = ImmutableMap.of("test 1", "foo", "test 2", uuid);
     private final List<Operation> operations = ImmutableList.of(randomOperation(), randomOperation(), randomOperation());
+    private final UUID resource = UUID.randomUUID();
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void equality() {
         new EqualsTester()
-                .addEqualityGroup(new Patch(operations, headers), new Patch(operations, headers))
-                .addEqualityGroup(new Patch(operations))
-                .addEqualityGroup(new Patch(ImmutableList.of(randomOperation()), headers))
-                .addEqualityGroup(new Patch(ImmutableList.of(randomOperation())))
+                .addEqualityGroup(new Patch<>(resource, operations, headers), new Patch<>(resource, operations, headers))
+                .addEqualityGroup(new Patch<>(resource, operations))
+                .addEqualityGroup(new Patch<>(resource, ImmutableList.of(randomOperation()),
+                        ImmutableMap.of("test 1", "bar", "test 2", uuid)))
+                .addEqualityGroup(new Patch<>(resource, ImmutableList.of(randomOperation())))
+                .addEqualityGroup(new Patch<>(resource, ImmutableList.of(randomOperation())))
                 .testEquals();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void immutableOperations() {
-        new Patch(operations, headers).getOperations().add(randomOperation());
+    @Test
+    public void getHeader() {
+        Patch<?> patch = new Patch<>(resource, operations, headers);
+        String stringHeader = patch.getHeader("test 1");
+        assertThat(stringHeader, is(equalTo("foo")));
+        UUID uuidHeader = patch.getHeader("test 2");
+        assertThat(uuidHeader, is(equalTo(uuid)));
+    }
+
+    @Test
+    public void isEmpty() {
+        assertTrue(new Patch<>(resource).isEmpty());
+        assertTrue(new Patch<>(resource, headers).isEmpty());
+        assertFalse(new Patch<>(resource, operations, headers).isEmpty());
+    }
+
+    @Test
+    public void size() {
+        assertThat(new Patch<>(resource).size(), is(equalTo(0)));
+        assertThat(new Patch<>(resource, operations, headers).size(), is(equalTo(operations.size())));
+    }
+
+    @Test
+    public void stream() {
+        assertThat(operations, is(equalTo(new Patch<>(resource, operations).stream().collect(Collectors.toList()))));
+    }
+
+    @Test
+    public void getter() {
+        Date timestamp = new Date();
+        Patch<UUID> patch = new Patch<>(resource, operations, headers, timestamp);
+        assertThat(patch.getResource(), is(equalTo(resource)));
+        assertThat(patch.getTimestamp(), is(equalTo(timestamp)));
+        for (int i = 0; i < operations.size(); i++) {
+            assertThat(patch.getOperation(i), is(equalTo(operations.get(i))));
+        }
+    }
+
+    @Test
+    public void getNotExistentHeader() {
+        String value = new Patch<>(resource, operations, headers).getHeader("test 7");
+        assertNull(value);
+    }
+
+    @Test
+    public void getHeaderWithIncompatibleType() {
+        Patch<UUID> patch = new Patch<>(resource, operations, headers);
+        assertTrue(patch.hasHeader("test 1"));
+
+        exception.expect(ClassCastException.class);
+        @SuppressWarnings("unused")
+        UUID value = patch.getHeader("test 1");
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void immutableHeaders() {
-        new Patch(operations, headers).getHeaders().remove("test 1");
+    public void immutableHeadersRemove() {
+        new Patch<>(resource, operations, headers).getHeaders().remove("test 1");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void immutableHeadersPut() {
+        new Patch<>(resource, operations, headers).getHeaders().put("foo", 22);
     }
 }

--- a/src/test/java/io/datanerds/avropatch/operation/PathTest.java
+++ b/src/test/java/io/datanerds/avropatch/operation/PathTest.java
@@ -9,9 +9,9 @@ import org.junit.rules.ExpectedException;
 
 import static io.datanerds.avropatch.operation.Path.ROOT;
 import static io.datanerds.avropatch.operation.Path.SLASH;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.emptyIterableOf;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.Assert.assertThat;
 
 public class PathTest {
@@ -92,10 +92,31 @@ public class PathTest {
     }
 
     @Test
+    public void leaf() {
+        Path path = Path.of("hello", "world");
+        assertThat(path.leaf(), is(equalTo(Path.of("world"))));
+        assertThat(ROOT.leaf(), is(equalTo(ROOT)));
+    }
+
+    @Test
     public void parts() {
         Path path = Path.of("hello", "world");
-        assertThat(path.parts(), hasItems("hello", "world"));
-        assertThat(path.parts().size(), is(equalTo(2)));
+        assertThat(path.parts(), allOf(
+                iterableWithSize(2),
+                hasItems("hello", "world")));
+    }
+
+    @Test
+    public void subPaths() {
+        Path path = Path.of("hello", "world");
+        assertThat(path.subPaths(), allOf(
+                iterableWithSize(2),
+                hasItems(Path.of("hello"), Path.parse("/hello/world"))));
+    }
+
+    @Test
+    public void subPathsOfRoot() {
+        assertThat(ROOT.subPaths(), emptyIterableOf(Path.class));
     }
 
     @Test
@@ -106,9 +127,12 @@ public class PathTest {
     }
 
     @Test
-    public void asString() {
-        Path path = Path.of("hello", "world");
-        assertThat(path.toString(), is(equalTo("/hello/world")));
+    public void pathAsString() {
+        assertThat(Path.of("hello", "world").toString(), is(equalTo("/hello/world")));
+    }
+
+    @Test
+    public void rootAsString() {
         assertThat(ROOT.toString(), is(equalTo("/")));
     }
 

--- a/src/test/java/io/datanerds/avropatch/serialization/ConcurrencyTest.java
+++ b/src/test/java/io/datanerds/avropatch/serialization/ConcurrencyTest.java
@@ -93,7 +93,7 @@ public class ConcurrencyTest {
             for (int j = 0; j < random.nextInt(MAX_PATCH_SIZE); j++) {
                 operations.add(OperationGenerator.randomOperation());
             }
-            patches.add(new Patch(operations));
+            patches.add(new Patch<>(UUID.randomUUID(), operations));
         }
         return patches;
     }

--- a/src/test/java/io/datanerds/avropatch/serialization/PatchMapperTest.java
+++ b/src/test/java/io/datanerds/avropatch/serialization/PatchMapperTest.java
@@ -21,10 +21,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PatchMapperTest {
 
+    private final UUID resource = UUID.randomUUID();
+
     @Test
     public void withCustomTypes() throws IOException {
         PatchMapper serializer = PatchMapper.builder().withCustomTypes().build();
-        Patch patch = new Patch(ImmutableList.of(new Add(Path.of("hello"), new BigDecimal("23946712384.49879324"))));
+        Patch patch = new Patch<>(resource,
+                ImmutableList.of(new Add<>(Path.of("hello"), new BigDecimal("23946712384.49879324"))));
         byte[] bytes = serializer.toBytes(patch);
         assertThat(patch, is(equalTo(serializer.toPatch(bytes))));
     }
@@ -39,12 +42,11 @@ public class PatchMapperTest {
                         .build())
                 .withType(Bimmel.class)
                 .build();
-        Patch patch = new Patch(ImmutableList.of(
-                new Replace(Path.of("hello"), new Bimmel("string", 42, UUID.randomUUID(), new Bimmel.Bommel("Gaga")))));
+        Patch patch = new Patch<>(resource, ImmutableList.of(
+                new Replace<>(Path.of("hello"), new Bimmel("string", 42, UUID.randomUUID(), new Bimmel.Bommel("Gaga")))));
         byte[] bytes = serializer.toBytes(patch);
         assertThat(patch, is(equalTo(serializer.toPatch(bytes))));
     }
-
 
     @Test
     public void withMultipleOperations() throws IOException {
@@ -57,13 +59,13 @@ public class PatchMapperTest {
                 .withAvroPrimitives()
                 .withType(Bimmel.class)
                 .build();
-        Patch patch = new Patch(ImmutableList.of(
-                new io.datanerds.avropatch.operation.Test(Path.of("hello", "world"), null),
-                new Add(Path.of("hello", "world"), "string"),
-                new Replace(Path.of("hello"), new Bimmel("string", 42, UUID.randomUUID(), new Bimmel.Bommel("Gaga"))),
+        Patch patch = new Patch<>(resource, ImmutableList.of(
+                new io.datanerds.avropatch.operation.Test<>(Path.of("hello", "world"), null),
+                new Add<>(Path.of("hello", "world"), "string"),
+                new Replace<>(Path.of("hello"), new Bimmel("string", 42, UUID.randomUUID(), new Bimmel.Bommel("Gaga"))),
                 new Copy(Path.of("from", "here"), Path.of("to", "there")),
-                new Add(Path.of("oO"), ImmutableList.of(new BigInteger("897696124"), 42, new BigInteger("4796923435"))),
-                new Replace(Path.of("lol"), ImmutableList.of(new Date(), new Date(), new Date()))));
+                new Add<>(Path.of("oO"), ImmutableList.of(new BigInteger("897696124"), 42, new BigInteger("4796923435"))),
+                new Replace<>(Path.of("lol"), ImmutableList.of(new Date(), new Date(), new Date()))));
         byte[] bytes = serializer.toBytes(patch);
         assertThat(patch, is(equalTo(serializer.toPatch(bytes))));
     }


### PR DESCRIPTION
- Added convenience methods for handling of `Patch` operations #13 
  - `Patch#size()`
  - `Patch#stream()`
  - `Patch#getOperation(int index)`
  - `<T> Patch#getHeader(String name)`
  - ...

- Added metadata information #11 
  - `timestamp` to specify when the PATCH request was made
  - `resource` representing the object to be updated by PATCH call